### PR TITLE
Adds pixel data check on input data. Exits success if no pixel data present

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 #
 # Example usage:
 #   docker run --rm -ti \
-#       -v <someDirWithDicoms>:/flywheel/v0/input/dcm2niix \
+#       -v <someDirWithDicoms>:/flywheel/v0/input/dcm2niix_input \
 #       -v <emptyOutputFolder>:/flywheel/v0/output \
 #       scitran/dcm2niix <optional_flags>
 #
@@ -20,7 +20,8 @@ RUN apt-get update -qq \
     unzip \
     pigz \
     gzip \
-    wget
+    wget \
+    vtk-dicom-tools
 
 # Install jq to parse manifest
 RUN wget -N -qO- -O /usr/bin/jq http://stedolan.github.io/jq/download/linux64/jq

--- a/run
+++ b/run
@@ -124,9 +124,25 @@ if [[ -d "$dicom_input" ]]; then
   fi
 fi
 
+
+##############################################################################
+# Use dicomdump to check for Pixel Data dicom tag (7FE0,0010)
+#  If no Pixel Data within ANY of the input files, algorithm will not execute and exit with a 0
+# Using dicomdump command from vtk-dicom-tools (https://github.com/dgobbi/vtk-dicom/wiki/Command-Line-Tools)
+
+# Get each file in unzipped dir
+input_files=`ls $dicom_input`
+for infile in $input_files
+do
+    pixeldata_check=$(dicomdump $dicom_input/$infile | grep "(7FE0,0010)")
+    if ! [[ $pixeldata_check ]]; then
+        echo "No Pixel Data within input dataset. dcm2niix will not execute. Exiting(0)..."
+        exit 0
+    fi
+done
+
 ##############################################################################
 # Run the dcm2niix algorithm passing forth the ENV vars with config
-
 dcm2niix -b ${config_bids_sidecar} \
          -m ${config_merge2d} \
          -t ${config_text_notes_private} \


### PR DESCRIPTION
Fixes #6 

Overview of change:
- A dicom "reader" was added to the Dockerfile in order to inspect the dicom to determine if pixel data is present
- Every file within the unzipped directory is checked for pixel data, if ANY one of those files does not contain the PixelData DICOM tag, dcm2niix is not executed and exits with a 0 returncode

Testing:
- Ran the gear on zipped T1 images and dcm2niix ran successfully and produced an output file
- Ran the gear on zipped PhoenixZipReport files (does not contain DICOM tag PixelData) and dcm2niix did not execute, returned a 0 exit code and did not produce any outputs.