### PR TITLE
dcm2niix Exitstatus

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,12 +15,25 @@ MAINTAINER Michael Perry <lmperry@stanford.edu>
 # Install packages
 RUN apt-get update -qq \
     && apt-get install -y \
-    dcm2niix=1:1.0.20170130-2~nd14.04+1 \
+    git \
+    curl \
+    build-essential \
+    cmake \
+    pkg-config \
     libgdcm-tools=2.2.4-1.1ubuntu4 \
+    bsdtar \
     unzip \
     pigz \
     gzip \
     wget
+
+# Compile DCM2NIIX from source
+ENV DCMCOMMIT=7fb7bcc56348f3a61012bba851bfa11057e55dc1
+RUN curl -#L  https://github.com/rordenlab/dcm2niix/archive/$DCMCOMMIT.zip | bsdtar -xf- -C /usr/local
+WORKDIR /usr/local/dcm2niix-${DCMCOMMIT}/build
+RUN cmake ../ && \
+    make && \
+    make install
 
 # Install jq to parse manifest
 RUN wget -N -qO- -O /usr/bin/jq http://stedolan.github.io/jq/download/linux64/jq

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ RUN apt-get update -qq \
     jq
 
 # Compile DCM2NIIX from source
-ENV DCMCOMMIT=7fb7bcc56348f3a61012bba851bfa11057e55dc1
+ENV DCMCOMMIT=efeddd8e06050599159e78dba43e33b3b58dce12
 RUN curl -#L  https://github.com/rordenlab/dcm2niix/archive/$DCMCOMMIT.zip | bsdtar -xf- -C /usr/local
 WORKDIR /usr/local/dcm2niix-${DCMCOMMIT}/build
 RUN cmake -DUSE_OPENJPEG=ON ../ && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ RUN apt-get update -qq \
 ENV DCMCOMMIT=7fb7bcc56348f3a61012bba851bfa11057e55dc1
 RUN curl -#L  https://github.com/rordenlab/dcm2niix/archive/$DCMCOMMIT.zip | bsdtar -xf- -C /usr/local
 WORKDIR /usr/local/dcm2niix-${DCMCOMMIT}/build
-RUN cmake ../ && \
+RUN cmake -DUSE_OPENJPEG=ON ../ && \
     make && \
     make install
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,8 @@ RUN apt-get update -qq \
     unzip \
     pigz \
     gzip \
-    wget
+    wget \
+    jq
 
 # Compile DCM2NIIX from source
 ENV DCMCOMMIT=7fb7bcc56348f3a61012bba851bfa11057e55dc1
@@ -35,13 +36,9 @@ RUN cmake -DUSE_OPENJPEG=ON ../ && \
     make && \
     make install
 
-# Install jq to parse manifest
-RUN wget -N -qO- -O /usr/bin/jq http://stedolan.github.io/jq/download/linux64/jq
-RUN chmod +x /usr/bin/jq
-
 # Make directory for flywheel spec (v0)
 ENV FLYWHEEL /flywheel/v0
-RUN mkdir -p ${FLYWHEEL}
+WORKDIR ${FLYWHEEL}
 
 # Add executables
 COPY run ${FLYWHEEL}/run

--- a/manifest.json
+++ b/manifest.json
@@ -1,65 +1,70 @@
 {
-	"name": "dcm2niix",
-	"label": "DCM2NIIX: v1.0.20170130",
-	"description": "Chris Rorden's dcm2niiX version v1.0.20170130 (64-bit Linux). dcm2niix is a popular tool for converting images from the complicated formats used by scanner manufacturers (DICOM, PAR/REC) to the simple NIfTI format used by many scientific tools. dcm2niix works for all modalities (CT, MRI, PET, SPECT) and sequence types.",
-	"maintainer": "Michael Perry <lmperry@stanford.edu>",
-	"author": "Chris Rorden",
-	"url": "https://www.nitrc.org/projects/dcm2nii",
-	"source": "https://github.com/scitran-apps/dcm2niix",
-	"license":  "BSD-2-Clause",
-	"flywheel": "0",
-	"version":  "0.1.1",
-	"config": {
-		"decompress_dicoms": {
-			"default": false,
-			"type": "boolean",
-			"description": "Decompress dicom files prior to conversion. This will perform decompression using gdcmconv and subsequently perform conversion using dcm2niix. (true/false, default=false)"
-		},
-		"bids_sidecar": {
-			"description": "Output BIDS sidecar in JSON format. (y/n, default n)",
-			"type": "string",
-			"default": "n",
-			"id": "-b"
-		},
-		"merge2d": {
-			"description": "merge 2D slices from same series regardless of study time, echo, coil, orientation, etc. (y/n, default n)",
-			"type": "string",
-			"default": "n",
-			"id": "-m"
-		},
-		"text_notes_private": {
-			"description": "text notes includes private patient details (y/n, default n)",
-			"type": "string",
-			"default": "n",
-			"id": "-t"
-		},
-		"crop": {
-			"description": "Crop images (y/n, default n)",
-			"type": "string",
-			"default": "n",
-			"id": "-x"
-		},
-		"compress_nifti":{
-			"description": "Compress output NIfTI file. Options, y=pigz, i=internal, n=no. (y/i/n, default=y) ",
-			"type": "string",
-			"default": "y",
-			"id": "-z"
-		},
-		"filename": {
-			"description": "Determine how files are named: filename (%a=antenna (coil) number, %c=comments, %d=description, %e=echo number, %f=folder name, %i=ID of patient, %m=manufacturer, %n=name of patient, %p=protocol, %s=series number, %t=time, %u=acquisition number, %z=sequence name; [default='%f'])",
-			"type": "string",
-			"default": "%f",
-			"id": "-f"
-		}
-	},
-	"inputs": {
-		"dcm2niix_input": {
-			"description": "Input file for dcm2niix. This can be either a DICOM archive ('.dicom.zip'), an enhanced dicom file (gzipped or not, e.g., 'IM0001.gz', 'IM0001'), or a PAR/REC archive ('.parrec.zip')",
-			"base": "file",
-			"type": { "enum": [ "dicom", "parrec" ] }
-		}
-	},
-	"custom": {
-		"docker-image": "scitran/dcm2niix:v0.1.1"
-	}
+  "name": "dcm2niix",
+  "label": "DCM2NIIX: v1.0.20170724",
+  "description": "Chris Rorden's dcm2niiX (v1.0.20170724 (OpenJPEG build) GCC4.8.4 (64-bit Linux)). dcm2niix is a popular tool for converting images from the complicated formats used by scanner manufacturers (DICOM, PAR/REC) to the simple NIfTI format used by many scientific tools. dcm2niix works for all modalities (CT, MRI, PET, SPECT) and sequence types.",
+  "maintainer": "Michael Perry <lmperry@stanford.edu>",
+  "author": "Chris Rorden (@neurolabusc)",
+  "url": "https://github.com/rordenlab/dcm2niix",
+  "source": "https://github.com/scitran-apps/dcm2niix",
+  "license": "BSD-2-Clause",
+  "flywheel": "0",
+  "version": "0.2",
+  "config": {
+    "decompress_dicoms": {
+      "default": false,
+      "type": "boolean",
+      "description": "Decompress DICOM files prior to conversion. This will perform decompression using gdcmconv and then perform conversion using dcm2niix. (true/false, default=false)"
+    },
+    "bids_sidecar": {
+      "description": "Output BIDS sidecar in JSON format. (y/n, default n)",
+      "type": "string",
+      "default": "n",
+      "id": "-b"
+    },
+    "merge2d": {
+      "description": "merge 2D slices from same series regardless of study time, echo, coil, orientation, etc. (y/n, default n)",
+      "type": "string",
+      "default": "n",
+      "id": "-m"
+    },
+    "text_notes_private": {
+      "description": "text notes includes private patient details (y/n, default n)",
+      "type": "string",
+      "default": "n",
+      "id": "-t"
+    },
+    "crop": {
+      "description": "Crop images (y/n, default n)",
+      "type": "string",
+      "default": "n",
+      "id": "-x"
+    },
+    "compress_nifti": {
+      "description": "Compress output NIfTI file. Options, y=pigz, i=internal, n=no. (y/i/n, default=y) ",
+      "type": "string",
+      "default": "y",
+      "id": "-z"
+    },
+    "filename": {
+      "description": "Determine how files are named: filename (%a=antenna (coil) number, %c=comments, %d=description, %e=echo number, %f=folder name, %i=ID of patient, %m=manufacturer, %n=name of patient, %p=protocol, %s=series number, %t=time, %u=acquisition number, %z=sequence name; [default='%f'])",
+      "type": "string",
+      "default": "%f",
+      "id": "-f"
+    }
+  },
+  "inputs": {
+    "dcm2niix_input": {
+      "description": "Input file for dcm2niix. This can be either a DICOM archive ('.dicom.zip'), an enhanced dicom file (gzipped or not, e.g., 'IM0001.gz', 'IM0001'), or a PAR/REC archive ('.parrec.zip')",
+      "base": "file",
+      "type": {
+        "enum": [
+          "dicom",
+          "parrec"
+        ]
+      }
+    }
+  },
+  "custom": {
+    "docker-image": "scitran/dcm2niix:v0.2"
+  }
 }

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "dcm2niix",
-  "label": "DCM2NIIX: v1.0.20170724",
-  "description": "Chris Rorden's dcm2niiX (v1.0.20170724 (OpenJPEG build) GCC4.8.4 (64-bit Linux)). dcm2niix is a popular tool for converting images from the complicated formats used by scanner manufacturers (DICOM, PAR/REC) to the simple NIfTI format used by many scientific tools. dcm2niix works for all modalities (CT, MRI, PET, SPECT) and sequence types.",
+  "label": "DCM2NIIX: v1.0.20170818",
+  "description": "Chris Rorden's dcm2niiX version v1.0.20170818 (OpenJPEG build) GCC4.8.4 (64-bit Linux). dcm2niix is a popular tool for converting images from the complicated formats used by scanner manufacturers (DICOM, PAR/REC) to the simple NIfTI format used by many scientific tools. dcm2niix works for all modalities (CT, MRI, PET, SPECT) and sequence types.",
   "maintainer": "Michael Perry <lmperry@stanford.edu>",
   "author": "Chris Rorden (@neurolabusc)",
   "url": "https://github.com/rordenlab/dcm2niix",

--- a/manifest.json
+++ b/manifest.json
@@ -50,11 +50,35 @@
       "type": "string",
       "default": "%f",
       "id": "-f"
+    },
+    "anonymize_bids": {
+      "description": "Anonymize BIDS (y/n, default n)",
+      "type": "string",
+      "default": "n",
+      "id": "-ba"
+    },
+    "ignore_derived": {
+      "description": "ignore derived, localizer and 2D images (y/n, default n)",
+      "type": "string",
+      "default": "n",
+      "id": "-i"
+    },
+    "philips_scaling": {
+      "description": "Philips precise float (not display) scaling (y/n, default y)",
+      "type": "string",
+      "default": "y",
+      "id": "-p"
+    },
+    "single_file_mode": {
+      "description": "single file mode, do not convert other images in folder (y/n, default n)",
+      "type": "string",
+      "default": "n",
+      "id": "-s"
     }
   },
   "inputs": {
     "dcm2niix_input": {
-      "description": "Input file for dcm2niix. This can be either a DICOM archive ('.dicom.zip'), an enhanced dicom file (gzipped or not, e.g., 'IM0001.gz', 'IM0001'), or a PAR/REC archive ('.parrec.zip')",
+      "description": "Input file for dcm2niix. This can be either a DICOM archive ('.dicom.zip'), an enhanced DICOM file (gzipped or not, e.g., 'IM0001.gz', 'IM0001'), or a PAR/REC archive ('.parrec.zip')",
       "base": "file",
       "type": {
         "enum": [

--- a/run
+++ b/run
@@ -44,7 +44,7 @@ fi
 # Handle INPUT.
 
 # The input to this Gear can be either a zip, a tgz, or a mounted volume
-# contianing DICOMs. Below we handle all those cases.
+# containing DICOMs. Below we handle all those cases.
 
 input_file=$(find $INPUT_DIR/* -not -path '*/\.*' -type f | head -1)
 dicom_input=''
@@ -80,12 +80,12 @@ elif [[ "$input_file" == *.gz ]]; then
   dicom_input=$(basename "$input_file" .gz)
 
 else
-  # Assume a directory containing dicoms was mounted in and pass it on (local run)
+  # Assume a directory containing dicoms was mounted in and pass it on (local docker execution)
   dicom_input=$INPUT_DIR
 fi
 
 ##############################################################################
-# Decompression of dicom files.
+# Decompression of DICOM files.
 
 # For some types of DIOCM files compression can be applied to the image data which
 # will cause dcm2niix to fail. We use a method recommended by Rorden below to
@@ -99,11 +99,11 @@ if [[ $config_decompress_dicoms == 'true' ]]; then
   dicom_files=$(find "$dicom_input" -type f)
 
   # Decompress with gcdmconv in place (overwriting the compressed dicom)
-  echo -e "$CONTAINER Decompressing DICOM files..."
+  echo -e "$CONTAINER  Decompressing DICOM files..."
   for d in $dicom_files; do
     gdcmconv --raw "$d" "$d"
     if [[ $? != 0 ]]; then
-      echo -e "$CONTAINER Error decompressing dicoms!"
+      echo -e "$CONTAINER  Error decompressing DICOMs!"
       exit 1
     fi
   done
@@ -112,9 +112,9 @@ fi
 ##############################################################################
 # Sanitize dicom_input name
 
-# Remove .dicom from dicom_input (if it is a direcotry) for output filename.
+# Remove '.dicom' from dicom_input (if it's a directory) for output filename.
 # Otherwise with default behavior (including the input folder in the output
-# filename, we have a '.dicom.nii.gz' extension, which is silly.
+# filename) we have a '.dicom.nii.gz' extension, which is silly.
 
 if [[ -d "$dicom_input" ]]; then
   NEW_DIR=$(dirname "$dicom_input")/$(basename "$dicom_input" .dicom)
@@ -136,17 +136,19 @@ dcm2niix -b ${config_bids_sidecar} \
          -o ${OUTPUT_DIR} \
          "$dicom_input"
 
-##############################################################################
-# Check outputs/permissions and Exit
+dcm2niix_exit_code=$?
 
-if [[ $? == 0 ]]; then
+##############################################################################
+# Check exit status/outputs/permissions and exit
+
+if [[ $dcm2niix_exit_code == 0 ]]; then
   chmod -R 777 $OUTPUT_DIR
   echo -e "$CONTAINER  Success! Wrote:\n`ls $OUTPUT_DIR`"
   exit 0
-elif [[ $? == 2 ]]; then
-  echo -e "$CONTAINER No valid DICOM files found. Conversion not attempted."
+elif [[ $dcm2niix_exit_code == 2 ]]; then
+  echo -e "$CONTAINER  No valid DICOM files found (dcm2niix exit status = $dcm2niix_exit_code). Conversion was not attempted. Exiting(0)."
   exit 0
 else
-  echo -e "$CONTAINER Error converting DICOMs! Exit status = $?"
-  exit $?
+  echo -e "$CONTAINER  Error converting DICOMs! Exit status = $dcm2niix_exit_code"
+  exit $dcm2niix_exit_code
 fi

--- a/run
+++ b/run
@@ -127,13 +127,17 @@ fi
 ##############################################################################
 # Run the dcm2niix algorithm passing forth the ENV vars with config
 
-dcm2niix -b ${config_bids_sidecar} \
-         -m ${config_merge2d} \
-         -t ${config_text_notes_private} \
-         -x ${config_crop} \
-         -z ${config_compress_nifti} \
-         -f ${config_filename} \
-         -o ${OUTPUT_DIR} \
+dcm2niix -ba ${config_anonymize_bids} \
+         -b  ${config_bids_sidecar} \
+         -m  ${config_merge2d} \
+         -t  ${config_text_notes_private} \
+         -x  ${config_crop} \
+         -z  ${config_compress_nifti} \
+         -f  ${config_filename} \
+         -i  ${config_ignore_derived} \
+         -p  ${config_philips_scaling} \
+         -s  ${config_single_file_mode} \
+         -o  ${OUTPUT_DIR} \
          "$dicom_input"
 
 dcm2niix_exit_code=$?

--- a/run
+++ b/run
@@ -136,24 +136,17 @@ dcm2niix -b ${config_bids_sidecar} \
          -o ${OUTPUT_DIR} \
          "$dicom_input"
 
-if [[ $? != 0 ]]; then
-  echo -e "$CONTAINER Error converting dicoms! Exit status = $?"
-  exit $?
-fi
-
 ##############################################################################
 # Check outputs/permissions and Exit
 
-# Get a list of the files in the output directory
-outputs=`find $OUTPUT_DIR -not -path '*/\.*' -type f -name "*nii*"`
-
-# If output files exist, happily exit, if not exit 1.
-if [[ -n "$outputs" ]] ; then
+if [[ $? == 0 ]]; then
   chmod -R 777 $OUTPUT_DIR
   echo -e "$CONTAINER  Success! Wrote:\n`ls $OUTPUT_DIR`"
+  exit 0
+elif [[ $? == 2 ]]; then
+  echo -e "$CONTAINER No valid DICOM files found. Conversion not attempted."
+  exit 0
 else
-  echo "$CONTAINER  No results found in output directory... Exiting(1)!"
-  exit 1
+  echo -e "$CONTAINER Error converting DICOMs! Exit status = $?"
+  exit $?
 fi
-
-exit 0


### PR DESCRIPTION
Closes #6 

1. Gear is now aware of dcm2niix new exit status for non-images. 
2. Builds dcm2niix from source with openjpeg compression support