### PR TITLE
Assigns file type of BIDS sidecar json as 'source code' instead of 'None'

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -8,9 +8,9 @@
   "source": "https://github.com/scitran-apps/dcm2niix",
   "license": "BSD-2-Clause",
   "flywheel": "0",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "custom": {
-    "docker-image": "scitran/dcm2niix:v0.3.1"
+    "docker-image": "scitran/dcm2niix:v0.3.2"
   },
   "config": {
     "decompress_dicoms": {

--- a/metadata.py
+++ b/metadata.py
@@ -62,6 +62,9 @@ def metadata_gen(outbase, bids_sidecar_dir, config_file):
             elif f.endswith('bval'):
                 ftype = 'bval'
                 bids_sidecar = os.path.join(bids_sidecar_dir, f.replace('.bval','.json'))
+            elif f.endswith('json'):
+                ftype = 'source code'
+                bids_sidecar = []
             else:
                 ftype = 'None'
                 bids_sidecar = []


### PR DESCRIPTION
Fixes #14 

This is something I discovered myself. Open to feedback! Thanks!