### PR TITLE
add logic to create subdir if doesn't exist

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -8,9 +8,9 @@
   "source": "https://github.com/scitran-apps/dcm2niix",
   "license": "BSD-2-Clause",
   "flywheel": "0",
-  "version": "0.7.8_1.0.20190410",
+  "version": "0.7.9_1.0.20190410",
   "custom": {
-    "docker-image": "scitran/dcm2niix:0.7.8_1.0.20190410",
+    "docker-image": "scitran/dcm2niix:0.7.9_1.0.20190410",
     "flywheel": {
       "uid": 1000,
       "gid": 1000,

--- a/run_dcm2niix
+++ b/run_dcm2niix
@@ -120,6 +120,17 @@ if [[ "$input_file" == *.zip ]] ; then
             new_folder=${new_folder/.dcm/}
             # remove .dicom
             new_folder=${new_folder/.dicom/}
+            # replace non-alphanumerics with _, avoiding repeat _
+            re='(.*)([^0-9a-zA-Z_]+|[_]{2,})(.*)'
+            while [[ $new_folder =~ $re ]]; do
+              new_folder="${BASH_REMATCH[1]}_${BASH_REMATCH[3]}"
+            done
+            # don't end on a _
+            re='(.*)[_]$'
+            if [[ $new_folder =~ $re ]]; then
+              new_folder=${BASH_REMATCH[1]}
+              echo $new_folder
+            fi
             # create full path
             new_folder="$INPUT_DIR"/"$new_folder"
             echo "$input_file did not contain a subdirectory - moving $count extracted files to $new_folder"

--- a/run_dcm2niix
+++ b/run_dcm2niix
@@ -108,6 +108,31 @@ if [[ "$input_file" == *.zip ]] ; then
         find $INPUT_DIR/* -not -path '*/\.*' -type f -name "*.par" -o -name "*.PAR" -exec mv {} $dicom_input \;
         find $INPUT_DIR/* -not -path '*/\.*' -type f -name "*.rec" -o -name "*.REC" -exec mv {} $INPUT_DIR/inputfile.rec \;
       fi
+      # Handle zips without subdirectories
+      if [[ -z "$dicom_input" ]]; then
+        if [[ ${filename} == "%f" ]]; then
+          # count the non-zip files extracted
+          file_count=$(find $INPUT_DIR -maxdepth 1 -type f -not -name *.zip | wc -l)
+          if ((file_count > 0)); then
+            # get basename of file and remove .zip
+            new_folder=$(basename "$input_file" .zip)
+            # remove .dcm
+            new_folder=${new_folder/.dcm/}
+            # remove .dicom
+            new_folder=${new_folder/.dicom/}
+            # create full path
+            new_folder="$INPUT_DIR"/"$new_folder"
+            echo "$input_file did not contain a subdirectory - moving $count extracted files to $new_folder"
+            # create the new directory
+            mkdir $new_folder
+
+            # move files that are not the zip to the new folder
+            find $INPUT_DIR -maxdepth 1 -type f -not -name *.zip -exec mv {} $new_folder \;
+            # try setting dicom_input again
+            dicom_input=$(find $INPUT_DIR/* -not -path '*/\.*' -not -path '__MACOSX' -type d | head -1)
+          fi
+        fi
+      fi
   fi
 
   # Zip bomb: DICOMS are at the top level -- set dicom_input to INPUT_DIR

--- a/run_dcm2niix
+++ b/run_dcm2niix
@@ -110,7 +110,7 @@ if [[ "$input_file" == *.zip ]] ; then
       fi
       # Handle zips without subdirectories
       if [[ -z "$dicom_input" ]]; then
-        if [[ ${filename} == "%f" ]]; then
+        if [[ ${filename} == *"%f"* ]]; then
           # count the non-zip files extracted
           file_count=$(find $INPUT_DIR -maxdepth 1 -type f -not -name *.zip | wc -l)
           if ((file_count > 0)); then


### PR DESCRIPTION
If the input was unzipped without a subdirectory, filename is set to %f, and files were actually extracted, the gear will now create a subdirectory named after the input file (with ".dcm", ".dicom", ".zip" removed) and move all extracted files to this subdirectory.