### PR TITLE
[GEAR-285] Upgrade to dcm2niix to 20190902

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@
 #
 
 # Start with neurodebian image
-FROM neurodebian:trusty
+FROM neurodebian:xenial
 MAINTAINER Michael Perry <lmperry@stanford.edu>
 
 # Install packages
@@ -20,26 +20,21 @@ RUN apt-get update -qq \
     build-essential \
     cmake \
     pkg-config \
-    libgdcm-tools=2.2.4-1.1ubuntu4 \
+    libgdcm-tools \
     bsdtar \
     unzip \
     pigz \
     gzip \
     wget \
     jq \
-    python \
+    python-pip \
     python-nibabel
-
-# Need to update pydicom
-RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \
-    python get-pip.py
 
 COPY requirements.txt ./requirements.txt
 RUN pip install -r requirements.txt && rm -rf /root/.cache/pip
 
 # Compile DCM2NIIX from source
-ENV DCMCOMMIT=54cfd5176cb9f50c1c66d2f2e96beadf60e2edb4
-#ENV DCMCOMMIT=f54be46667fce7994d2062e2623d12253c1bd968
+ENV DCMCOMMIT=f54be46667fce7994d2062e2623d12253c1bd968
 RUN curl -#L  https://github.com/rordenlab/dcm2niix/archive/$DCMCOMMIT.zip | bsdtar -xf- -C /usr/local
 WORKDIR /usr/local/dcm2niix-${DCMCOMMIT}/build
 RUN cmake -DUSE_OPENJPEG=ON -MY_DEBUG_GE=ON ../ && \

--- a/manifest.json
+++ b/manifest.json
@@ -8,9 +8,9 @@
   "source": "https://github.com/scitran-apps/dcm2niix",
   "license": "BSD-2-Clause",
   "flywheel": "0",
-  "version": "0.7.10_1.0.20190410",
+  "version": "0.8.0_1.0.20190902",
   "custom": {
-    "docker-image": "scitran/dcm2niix:0.7.10_1.0.20190410",
+    "docker-image": "scitran/dcm2niix:0.8.0_1.0.20190902",
     "flywheel": {
       "uid": 1000,
       "gid": 1000,
@@ -18,7 +18,7 @@
     },
     "gear-builder": {
       "category": "converter",
-      "image": "scitran/dcm2niix:0.7.10_1.0.20190410"
+      "image": "scitran/dcm2niix:0.8.0_1.0.20190902"
     }
   },
   "config": {

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-pydicom==1.3.0
+pydicom==1.4.2


### PR DESCRIPTION
Upgrades:
1. dcm2niix to version 20190902 
2. pydicom to 1.4.2. 
3. Base image to xenial